### PR TITLE
Fix "maxsize" filter and remove unused "minsize" validation 

### DIFF
--- a/substantial.js
+++ b/substantial.js
@@ -83,7 +83,7 @@ Substantial.prototype._testTile = function _testTile(zoom, x, y, data) {
         Err.throwNoTile();
     }
     if (data.length >= self.params.maxsize) {
-        return; // generated tile is too big, save
+        return Promise.resolve(undefined); // generated tile is too big, save
     }
     let vt = new core.mapnik.VectorTile(zoom, x, y);
     return core.uncompressAsync(data).then(uncompressed => vt.setDataAsync(uncompressed)).then(() => {

--- a/substantial.js
+++ b/substantial.js
@@ -25,7 +25,7 @@ function Substantial(uri, callback) {
         }
         checkType(params, 'minzoom', 'integer', 0, 0, 22);
         checkType(params, 'maxzoom', 'integer', 22, params.minzoom + 1, 22);
-        checkType(params, 'maxsize', 'integer', true, 0);
+        checkType(params, 'maxsize', 'integer', undefined, 0);
         checkType(params, 'layers', 'string-array', true, 1);
         checkType(params, 'debug', 'boolean', false);
         self.params = params;

--- a/substantial.js
+++ b/substantial.js
@@ -25,9 +25,8 @@ function Substantial(uri, callback) {
         }
         checkType(params, 'minzoom', 'integer', 0, 0, 22);
         checkType(params, 'maxzoom', 'integer', 22, params.minzoom + 1, 22);
-        checkType(params, 'minsize', 'integer', 0, 0);
+        checkType(params, 'maxsize', 'integer', true, 0);
         checkType(params, 'layers', 'string-array', true, 1);
-        checkType(params, 'minsize', 'integer', 0, 0);
         checkType(params, 'debug', 'boolean', false);
         self.params = params;
         return core.loadSource(params.source);


### PR DESCRIPTION
`minsize` parameter is not used although its value is validated.

This PR defines and validates the `maxsize` parameter instead, and fixes the current implementation to return a promise when the tile size is bigger than this value (and the tile is not inspected).

Note that any existing configurations should not be disturbed by these modifications : `maxsize` default value is `undefined`.